### PR TITLE
Fix: Some Hooks Aren't Reactive

### DIFF
--- a/examples/geolocation/Cargo.toml
+++ b/examples/geolocation/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 [dependencies]
 dioxus-sdk = { workspace = true, features = ["geolocation"] }
 # You can change from 'desktop' to 'web' as well
-dioxus = { workspace = true, features = ["desktop"] } 
+dioxus = { workspace = true, features = ["web"] } 
 

--- a/examples/geolocation/Cargo.toml
+++ b/examples/geolocation/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 [dependencies]
 dioxus-sdk = { workspace = true, features = ["geolocation"] }
 # You can change from 'desktop' to 'web' as well
-dioxus = { workspace = true, features = ["web"] } 
+dioxus = { workspace = true, features = ["desktop"] } 
 

--- a/examples/geolocation/src/main.rs
+++ b/examples/geolocation/src/main.rs
@@ -18,7 +18,7 @@ fn app() -> Element {
     });
     let latest_coords = use_geolocation();
 
-    let latest_coords = match latest_coords {
+    let latest_coords = match latest_coords() {
         Ok(v) => v,
         Err(e) => {
             let e = format!("Initializing: {:?}", e);

--- a/examples/use_window_size/README.md
+++ b/examples/use_window_size/README.md
@@ -2,6 +2,11 @@
 
 Learn how to use `use_window_size`.
 
-Run:
 
-```dioxus serve```
+### Run
+
+**Desktop**
+```dioxus serve --platform desktop```
+
+**Web**
+```dioxus serve --platform web```

--- a/examples/use_window_size/src/main.rs
+++ b/examples/use_window_size/src/main.rs
@@ -17,8 +17,8 @@ fn app() -> Element {
             p { "Height: {initial_size().height}" }
 
             h3 { "Current Size" }
-            p { "Width: {window_size.width}" }
-            p { "Height: {window_size.height}" }
+            p { "Width: {window_size().width}" }
+            p { "Height: {window_size().height}" }
         }
     )
 }

--- a/sdk/src/utils/window.rs
+++ b/sdk/src/utils/window.rs
@@ -36,7 +36,7 @@ pub struct WindowSize {
 ///     }
 /// }
 /// ```
-pub fn use_window_size() -> WindowSize {
+pub fn use_window_size() -> ReadOnlySignal<WindowSize> {
     let mut window_size = use_signal(get_window_size);
 
     // Initialize the handler
@@ -48,7 +48,7 @@ pub fn use_window_size() -> WindowSize {
 
     listen(tx);
 
-    *window_size.read_unchecked()
+    use_hook(|| ReadOnlySignal::new(window_size))
 }
 
 // Listener for the web implementation.

--- a/sdk/src/utils/window.rs
+++ b/sdk/src/utils/window.rs
@@ -31,8 +31,8 @@ pub struct WindowSize {
 ///     let size = use_window_size();
 ///
 ///     rsx! {
-///         p { "Width: {size.width}" }
-///         p { "Height: {size.height}" }
+///         p { "Width: {size().width}" }
+///         p { "Height: {size().height}" }
 ///     }
 /// }
 /// ```


### PR DESCRIPTION
The geolocation and window size hooks were not reactive causing memos to not subscribe to changes. This PR fixes them by making them return a `ReadOnlySignal`.