### PR TITLE
Add web build command to storage example readme

### DIFF
--- a/examples/storage/README.md
+++ b/examples/storage/README.md
@@ -1,8 +1,16 @@
-# use_persistent (Desktop)
+# use_persistent
 
 
 Use persistent allows you to create data that will persist across sessions. This example will teach you how to use the `use_persistant` hook.
 
-Run:
+Desktop:
 
-```dioxus serve --platform desktop```
+```sh
+dioxus serve --platform desktop --features desktop
+```
+
+Web:
+
+```sh
+dioxus serve --features web
+```


### PR DESCRIPTION
Adds a separate command to run the storage example in the browser and removes `(Desktop)` which can make it seem like storage only works on the desktop platform