### PR TITLE
Fix: Debounce On WASM

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,6 @@
 {
     "rust-analyzer.cargo.features": [
-        "desktop-testing"
+        "wasm-testing"
     ],
-    "rust-analyzer.cargo.extraArgs": [
-        "--exclude=color_scheme"
-    ],
-    //"rust-analyzer.cargo.target": "wasm32-unknown-unknown",
+    "rust-analyzer.cargo.target": "wasm32-unknown-unknown",
 }

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -151,9 +151,6 @@ dioxus-signals = { version = "0.5.0-alpha.2", features = [
 yazi = { version = "0.1.4", optional = true }
 tracing = "0.1.40"
 
-# Used by: timing
-gloo-timers = { version = "0.3.0", optional = true }
-
 # Used by: timing & storage
 tokio = { version = "1.33.0", optional = true }
 
@@ -183,6 +180,9 @@ js-sys = "0.3.62"
 
 # Used by: channel
 uuid = { version = "1.3.2", features = ["js"] }
+
+# Used by: timing
+gloo-timers = { version = "0.3.0", optional = true, features = ["futures"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 # Used by: storage

--- a/sdk/src/utils/timing/debounce.rs
+++ b/sdk/src/utils/timing/debounce.rs
@@ -77,7 +77,12 @@ pub fn use_debounce<T>(time: Duration, cb: impl FnOnce(T) + Copy + 'static) -> U
                     }
 
                     current_task = Some(spawn(async move {
+                        #[cfg(not(target_family = "wasm"))]
                         tokio::time::sleep(time).await;
+
+                        #[cfg(target_family = "wasm")]
+                        gloo_timers::future::sleep(time).await;
+
                         cb(data);
                     }));
                 }


### PR DESCRIPTION
One of `use_debounce`'s dependencies used `std::time::Instant` which is not supported on wasm. This PR fixes that.