### PR TITLE
fix: Store the Clipboard context signal in the root scope

### DIFF
--- a/sdk/src/clipboard/use_clipboard.rs
+++ b/sdk/src/clipboard/use_clipboard.rs
@@ -61,8 +61,8 @@ pub fn use_clipboard() -> UseClipboard {
     let clipboard = match try_consume_context() {
         Some(rt) => rt,
         None => {
-            let clipboard = ScopeId::ROOT.in_runtime(|| ClipboardContext::new().ok());
-            let clipboard_signal = Signal::new_in_scope(clipboard, ScopeId::ROOT);
+            let clipboard_signal =
+                Signal::new_in_scope(ClipboardContext::new().ok(), ScopeId::ROOT);
             provide_root_context(clipboard_signal)
         }
     };

--- a/sdk/src/clipboard/use_clipboard.rs
+++ b/sdk/src/clipboard/use_clipboard.rs
@@ -61,8 +61,9 @@ pub fn use_clipboard() -> UseClipboard {
     let clipboard = match try_consume_context() {
         Some(rt) => rt,
         None => {
-            let clipboard = ClipboardContext::new().ok();
-            provide_root_context(Signal::new(clipboard))
+            let clipboard = ScopeId::ROOT.in_runtime(|| ClipboardContext::new().ok());
+            let clipboard_signal = Signal::new_in_scope(value, ScopeId::ROOT);
+            provide_root_context(clipboard_signal)
         }
     };
     UseClipboard { clipboard }

--- a/sdk/src/clipboard/use_clipboard.rs
+++ b/sdk/src/clipboard/use_clipboard.rs
@@ -62,7 +62,7 @@ pub fn use_clipboard() -> UseClipboard {
         Some(rt) => rt,
         None => {
             let clipboard = ScopeId::ROOT.in_runtime(|| ClipboardContext::new().ok());
-            let clipboard_signal = Signal::new_in_scope(value, ScopeId::ROOT);
+            let clipboard_signal = Signal::new_in_scope(clipboard, ScopeId::ROOT);
             provide_root_context(clipboard_signal)
         }
     };


### PR DESCRIPTION
Closes https://github.com/DioxusLabs/sdk/issues/54

I haven't tried it yet myself, it would be nice if somebody could test it.