### PR TITLE
Fix versions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ fn App() -> Element {
 You can add `dioxus-sdk` to your application by adding it to your dependencies.
 ```toml
 [dependencies]
-dioxus-sdk = { version = "0.7", features = [] }
+dioxus-sdk = { version = "0.6", features = [] }
 ```
 
 ### Dioxus Compatibility
@@ -90,8 +90,8 @@ The crate version supports a Dioxus version up until the next crate version in t
 E.g. if crate version `0.1` supported Dioxus `0.6` and crate version `0.4` supported Dioxus `0.7`, crate versions `0.1`, `0.2`, and `0.3` would support Dioxus `0.6`.
 
 | Crate Version | Dioxus Version |
-| ------------- | -------------- |
-| 0.7           | 0.6            |
+|---------------| -------------- |
+| 0.6           | 0.6            |
 | 0.5           | 0.5            |
 
 ## License


### PR DESCRIPTION
The [README.md](https://github.com/DioxusLabs/sdk/blob/main/README.md) of the current SDK references version 7.0, which is not yet available on [crates.io](https://crates.io/crates/dioxus-sdk). Since [the latest stable published version, dioxus-sdk 6.0](https://github.com/DioxusLabs/sdk/releases/tag/v0.6.0), supports Dioxus 6.0 but is not mentioned in the README, I have updated the README to reflect this.