### PR TITLE
Bump dioxus version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,10 +26,10 @@ dioxus-util = { path = "packages/util", version = "0.1.0-alpha.1" }
 dioxus-window = { path = "packages/window", version = "0.1.0-alpha.1" }
 
 # Dioxus
-dioxus = "0.6.0"
-dioxus-signals = "0.6.0"
-dioxus-desktop = "0.6.0"
-dioxus-config-macro = "0.6.0"
+dioxus = "0.7.0-alpha.0"
+dioxus-signals = "0.7.0-alpha.0"
+dioxus-desktop = "0.7.0-alpha.0"
+dioxus-config-macro = "0.7.0-alpha.0"
 
 # Deps
 cfg-if = "1.0.0"


### PR DESCRIPTION
This PR bumps diouxs to the current alpha version. Mainly just putting this up for visibility, there aren't any interesting changes required yet.

To use dioxus 0.7 with the SDK, you can add this patch to your cargo.toml:
