### PR TITLE
Replacing set_dir! string literal input by expression

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,10 +26,10 @@ dioxus-util = { path = "packages/util", version = "0.1.0-alpha.1" }
 dioxus-window = { path = "packages/window", version = "0.1.0-alpha.1" }
 
 # Dioxus
-dioxus = "0.6.0"
-dioxus-signals = "0.6.0"
-dioxus-desktop = "0.6.0"
-dioxus-config-macro = "0.6.0"
+dioxus = "0.7.0-alpha.1"
+dioxus-signals = "0.7.0-alpha.1"
+dioxus-desktop = "0.7.0-alpha.1"
+dioxus-config-macro = "0.7.0-alpha.1"
 
 # Deps
 cfg-if = "1.0.0"

--- a/packages/storage/src/client_storage/mod.rs
+++ b/packages/storage/src/client_storage/mod.rs
@@ -27,6 +27,10 @@ macro_rules! set_dir {
         #[cfg(not(target_family = "wasm"))]
         $crate::set_directory(std::path::PathBuf::from($path))
     };
+    ($path:expr) => {
+        #[cfg(not(target_family = "wasm"))]
+        $crate::set_directory($path);
+    };
 }
 
 cfg_if::cfg_if! {


### PR DESCRIPTION
Just a small PR to be able to do things like :
```rust
let mut path = std::env::home_dir().expect("nah");
path.push(".local/share/myapp/");
dioxus_storage::set_dir!(path);
```

I am not sure about the dioxus versions bump tho.