### PR TITLE
persistent use LocalStorage, not SessionStorage

### DIFF
--- a/packages/storage/src/persistence.rs
+++ b/packages/storage/src/persistence.rs
@@ -1,4 +1,4 @@
-use crate::SessionStorage;
+use crate::LocalStorage;
 use crate::{new_storage_entry, use_hydrate_storage};
 use dioxus::prelude::*;
 use dioxus_signals::Signal;
@@ -18,7 +18,7 @@ pub fn use_persistent<
 ) -> Signal<T> {
     let mut init = Some(init);
     let storage = use_hook(|| new_persistent(key.to_string(), || init.take().unwrap()()));
-    use_hydrate_storage::<SessionStorage, T>(storage, init);
+    use_hydrate_storage::<LocalStorage, T>(storage, init);
     storage
 }
 
@@ -31,7 +31,7 @@ pub fn new_persistent<
     key: impl ToString,
     init: impl FnOnce() -> T,
 ) -> Signal<T> {
-    let storage_entry = new_storage_entry::<SessionStorage, T>(key.to_string(), init);
+    let storage_entry = new_storage_entry::<LocalStorage, T>(key.to_string(), init);
     storage_entry.save_to_storage_on_change();
     storage_entry.data
 }
@@ -48,7 +48,7 @@ pub fn use_singleton_persistent<
 ) -> Signal<T> {
     let mut init = Some(init);
     let signal = use_hook(|| new_singleton_persistent(|| init.take().unwrap()()));
-    use_hydrate_storage::<SessionStorage, T>(signal, init);
+    use_hydrate_storage::<LocalStorage, T>(signal, init);
     signal
 }
 


### PR DESCRIPTION
In storage, persistent should use the LocalStorage, not the SessionStorage.
Addresses this issue: https://github.com/DioxusLabs/sdk/issues/98