### PR TITLE
impl Copy for UseChannel<MessageType: !Copy>

### DIFF
--- a/packages/sync/src/channel/use_channel.rs
+++ b/packages/sync/src/channel/use_channel.rs
@@ -3,12 +3,14 @@ use dioxus::prelude::*;
 use uuid::Uuid;
 
 /// Send and listen for messages between multiple components.
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub struct UseChannel<MessageType: Clone + 'static> {
     id: Uuid,
     sender: Signal<Sender<MessageType>>,
     inactive_receiver: Signal<InactiveReceiver<MessageType>>,
 }
+
+impl<T: Clone> Copy for UseChannel<T> {}
 
 impl<T: Clone> PartialEq for UseChannel<T> {
     fn eq(&self, other: &Self) -> bool {


### PR DESCRIPTION
Change to fix #112 
as its the only fields are `Uuid` and Signal<T> which are all Copy, it seems to me it'd be safe to implement it for all MessageType.

not 100% sure if it actually should be like this, feel free to refuse !